### PR TITLE
Non-greedy match of the target triple

### DIFF
--- a/cmake/Findrustc.cmake
+++ b/cmake/Findrustc.cmake
@@ -27,7 +27,7 @@ mark_as_advanced(RUSTC_EXECUTABLE)
 execute_process(COMMAND ${RUSTC_EXECUTABLE} -Vv
                 OUTPUT_VARIABLE RUSTC_TARGET_TRIPLE
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REGEX MATCH "host:[ \t](.*)\n" RUSTC_TARGET_TRIPLE "${RUSTC_TARGET_TRIPLE}")
+string(REGEX MATCH "host:[ \t]([^\n]*)\n" RUSTC_TARGET_TRIPLE "${RUSTC_TARGET_TRIPLE}")
 string(REGEX REPLACE "host:[ \t](.*)\n" "\\1" RUSTC_TARGET_TRIPLE "${RUSTC_TARGET_TRIPLE}")
 set(RUSTC_TARGET_TRIPLE "${RUSTC_TARGET_TRIPLE}" CACHE STRING "Target triple you can pass to rustc (not passed by default)")
 mark_as_advanced(RUSTC_TARGET_TRIPLE)


### PR DESCRIPTION
The former regexp captured next lines as well, causing corruption of CMakeCache.txt.